### PR TITLE
update /download /upload paths

### DIFF
--- a/source/api/app.py
+++ b/source/api/app.py
@@ -333,8 +333,8 @@ def create_filesystem_lambda(filesystem_id):
     else:
         return response
 
-# TODO: Change this url path to /objects/$fsid/upload
-@app.route('/upload/{filesystem_id}', methods=["POST"], cors=True, authorizer=authorizer)
+
+@app.route('/objects/{filesystem_id}/upload', methods=["POST"], cors=True, authorizer=authorizer)
 def upload(filesystem_id):
     print(app.current_request.query_params)
     try:
@@ -365,7 +365,7 @@ def upload(filesystem_id):
         raise ChaliceViewError('Error uploading file: {payload}'.format(payload=payload))
 
 
-@app.route('/download/{filesystem_id}', methods=["GET"], cors=True, authorizer=authorizer)
+@app.route('/objects/{filesystem_id}/download', methods=["GET"], cors=True, authorizer=authorizer)
 def download(filesystem_id):
     print(app.current_request.query_params)
     try:

--- a/source/web/src/components/download.vue
+++ b/source/web/src/components/download.vue
@@ -37,7 +37,7 @@ export default {
   },
   methods: {
     async downloadChunk (requestParams) {
-          let response = await API.get('fileManagerApi', '/api/download/' + this.$route.params.id, requestParams)
+          let response = await API.get('fileManagerApi', '/api/objects/' + this.$route.params.id + '/download', requestParams)
           return response
       },
     async downloadFile () {

--- a/source/web/src/components/upload.vue
+++ b/source/web/src/components/upload.vue
@@ -75,7 +75,7 @@ export default {
           },
           body: chunkData
       };
-      let response = await API.post('fileManagerApi', '/api/upload/' + this.$route.params.id, requestParams)
+      let response = await API.post('fileManagerApi', '/api/objects/' + this.$route.params.id + '/upload', requestParams)
       return response
     },
     // this whole function needs to be cleaned up, notably reduce duplicate code by breaking out into functions - works well for now though


### PR DESCRIPTION
*Issue #, if available:*

Closes #45 

*Description of changes:*

Move download and upload routes underneath /objects to follow the uniform route pattern 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
