### PR TITLE
allow delete of sfm resources + iam scoped down

### DIFF
--- a/deployment/efs-file-manager.yaml
+++ b/deployment/efs-file-manager.yaml
@@ -56,13 +56,10 @@ Resources:
               - Effect: Allow
                 Action:
                   - "iam:CreateRole"
-                  - "iam:AttachRolePolicy"
                 Resource: "arn:aws:iam::*:*"
               - Effect: Allow
                 Action:
                   - "lambda:CreateFunction"
-                  - "lambda:InvokeFunction"
-                  - "lambda:GetFunction"
                   - "ec2:DescribeSecurityGroups"
                   - "ec2:DescribeSubnets"
                   - "ec2:DescribeVpcs"
@@ -70,9 +67,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - "elasticfilesystem:DescribeMountTargets"
-                  - "elasticfilesystem:DeleteAccessPoint"
                   - "elasticfilesystem:DescribeFileSystems"
                   - "elasticfilesystem:CreateAccessPoint"
+                  - "elasticfilesystem:DescribeAccessPoints"
                   - "elasticfilesystem:DescribeMountTargetSecurityGroups"
                 Resource:
                   - "arn:aws:elasticfilesystem:*:*:file-system/*"
@@ -82,10 +79,29 @@ Resources:
                 Action:
                   - "iam:PassRole"
                 Resource:
-                  - "arn:aws:iam::*:role/fs-*"
+                  - "arn:aws:iam::*:role/fs-*-manager-role"
                 Condition:
                   StringEquals:
                     iam:PassedToService: lambda.amazonaws.com
+              - Effect: Allow
+                Action: 
+                  - "elasticfilesystem:DeleteAccessPoint"
+                Resource: "arn:aws:elasticfilesystem:*:*:access-point/*"
+                Condition:
+                  StringEquals:
+                    aws:ResourceTag/Name: "simple-file-manager-access-point"
+              - Effect: Allow
+                Action:
+                  - "iam:DetachRolePolicy"
+                  - "iam:AttachRolePolicy"
+                  - "iam:DeleteRole"
+                Resource: "arn:aws:iam::*:role/fs-*-manager-role"
+              - Effect: Allow
+                Action:
+                  - "lambda:InvokeFunction"
+                  - "lambda:GetFunction"
+                  - "lambda:DeleteFunction"
+                Resource: "arn:aws:lambda:*:*:function:fs-*-manager-lambda"
 
   # File Manager API stack
   EFSFileManagerAPI:

--- a/source/web/src/components/filesystems.vue
+++ b/source/web/src/components/filesystems.vue
@@ -11,7 +11,7 @@
         </template>
         <template v-slot:cell(managed)="data">
             <div v-if="data.value === true">
-                <p>{{data.value}}</p>
+                <a :href="`/details/${data.item.file_system_id}`">{{ data.value }}</a>
             </div>
             <div v-else-if="data.value === 'Creating'">
                 <b-link href="/" v-b-tooltip.hover title="Lambda creation can take several minutes. Click to refresh.">{{data.value}}</b-link>

--- a/source/web/src/components/navbar.vue
+++ b/source/web/src/components/navbar.vue
@@ -2,7 +2,7 @@
   <div>
     <b-navbar type="dark" variant="info">
         <b-navbar-nav>
-            <b-navbar-brand class='name' to='/'>Serverless File Manager</b-navbar-brand>
+            <b-navbar-brand class='name' to='/'>Simple File Manager</b-navbar-brand>
         </b-navbar-nav>
         <b-navbar-nav class="ml-auto">
           <amplify-sign-out class="signout" v-if="signedIn"></amplify-sign-out>

--- a/source/web/src/router.js
+++ b/source/web/src/router.js
@@ -5,6 +5,7 @@ import Home from '@/routes/Home.vue'
 import Configure from '@/routes/Configure.vue'
 import Filesystem from '@/routes/Filesystem.vue'
 import Login from '@/routes/Login.vue'
+import Details from '@/routes/Details.vue'
 
 Vue.use(VueRouter);
 
@@ -34,6 +35,12 @@ const router = new VueRouter({
       path: '/',
       name: 'home',
       component: Home,
+      meta: { requiresAuth: true }
+    },
+    {
+      path: '/details/:id',
+      name: 'details',
+      component: Details,
       meta: { requiresAuth: true }
     }
 ]

--- a/source/web/src/routes/Details.vue
+++ b/source/web/src/routes/Details.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <b-container class="bv-example-row bv-example-row-flex-cols">
+        <h1>Filesystem: {{ $route.params.id }}</h1>
+        <div v-if="processing">
+            <b-spinner/>
+        </div>
+        <div v-else>
+            <p> Remove Simple File Manager Resources?</p>
+            <b-button variant="danger" @click="deleteFileManager">Delete</b-button>
+        </div>
+    </b-container>
+  </div>
+</template>
+
+<script>
+import { API } from 'aws-amplify';
+
+export default {
+  name: 'Details',
+  data () {
+    return {
+        processing: false
+    }
+  },
+  methods: {
+      async deleteFileManager() {
+          try {
+              this.processing = true
+              await API.del('fileManagerApi', '/api/filesystems/' + this.$route.params.id + '/lambda')
+              this.processing = false
+              this.$router.push({ name: "home" })
+          }
+          catch (error) {
+              alert('Unable to delete filesystem manager resources, check api logs')
+              this.processing = false
+          }
+      }
+  }
+}
+
+
+</script>
+
+
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+
+
+</style>


### PR DESCRIPTION
*Issue #, if available:*

Closes #115 

*Description of changes:*

This PR allows the ability to delete all SFM resources (file manager lambda, IAM role, and access point) for a given filesystem. There is a new route that can be navigated to via the "true" link that is active when a file manager lambda is present. This PR also updates the API handler IAM role to support this change as well as misc further security scoping. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
