### PR TITLE
Moved managed resources creation to CloudFormation

### DIFF
--- a/deployment/efs-file-manager.yaml
+++ b/deployment/efs-file-manager.yaml
@@ -85,6 +85,11 @@ Resources:
                     iam:PassedToService: lambda.amazonaws.com
               - Effect: Allow
                 Action: 
+                  - "iam:GetRole"
+                Resource:
+                  - "arn:aws:iam::*:role/fs-*-manager-role"
+              - Effect: Allow
+                Action:
                   - "elasticfilesystem:DeleteAccessPoint"
                 Resource: "arn:aws:elasticfilesystem:*:*:access-point/*"
                 Condition:
@@ -102,6 +107,12 @@ Resources:
                   - "lambda:GetFunction"
                   - "lambda:DeleteFunction"
                 Resource: "arn:aws:lambda:*:*:function:fs-*-manager-lambda"
+              - Effect: Allow
+                Action:
+                  - "cloudformation:CreateStack"
+                  - "cloudformation:DeleteStack"
+                  - "cloudformation:DescribeStacks"
+                Resource: "arn:aws:cloudformation:*:*:stack/*"
 
   # File Manager API stack
   EFSFileManagerAPI:
@@ -131,6 +142,7 @@ Resources:
             "filemanagerapi.zip",
             ],
           ]
+        stackPrefix: !Sub "${AWS::StackName}"
 
   # Deploy Authentication stack.
   EFSFileAuthentication:

--- a/source/api/.chalice/config.json
+++ b/source/api/.chalice/config.json
@@ -2,7 +2,8 @@
   "version": "2.0",
   "app_name": "api",
   "environment_variables": {
-    "botoConfig": "{}"
+    "botoConfig": "{}",
+    "stackPrefix": ""
   },
   "stages": {
     "dev": {

--- a/source/api/app.py
+++ b/source/api/app.py
@@ -149,8 +149,8 @@ def create_manager_stack(filesystem_id, uid, gid, path, subnet_ids, security_gro
                     'ParameterValue': path,
                 },
                 {
-                    'ParameterKey': 'VpcConfigSgId',
-                    'ParameterValue': security_groups[0],
+                    'ParameterKey': 'VpcConfigSgIds',
+                    'ParameterValue': ','.join(security_groups),
                 },
                 {
                     'ParameterKey': 'VpcConfigSubnetId',

--- a/source/api/app.py
+++ b/source/api/app.py
@@ -153,8 +153,8 @@ def create_manager_stack(filesystem_id, uid, gid, path, subnet_ids, security_gro
                     'ParameterValue': ','.join(security_groups),
                 },
                 {
-                    'ParameterKey': 'VpcConfigSubnetId',
-                    'ParameterValue': subnet_ids[0],
+                    'ParameterKey': 'VpcConfigSubnetIds',
+                    'ParameterValue': ','.join(subnet_ids),
                 },
             ],
             TimeoutInMinutes=15,

--- a/source/api/chalicelib/file-manager-ap-lambda.template
+++ b/source/api/chalicelib/file-manager-ap-lambda.template
@@ -10,7 +10,7 @@ Parameters:
     Type: String
   RootDirectoryPath:
     Type: String
-  VpcConfigSgId:
+  VpcConfigSgIds:
     Type: String
   VpcConfigSubnetId:
     Type: String
@@ -240,6 +240,8 @@ Resources:
       Timeout: 60
       VpcConfig:
         SecurityGroupIds:
-          - !Ref VpcConfigSgId
+          Fn::Split:
+            - ","
+            - !Ref VpcConfigSgIds
         SubnetIds:
           - !Ref VpcConfigSubnetId

--- a/source/api/chalicelib/file-manager-ap-lambda.template
+++ b/source/api/chalicelib/file-manager-ap-lambda.template
@@ -1,0 +1,245 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Simple File Manager for Amazon EFS - Deploys the EFS Access Point and Lambda to manage an EFS file system
+
+Parameters:
+  FileSystemId:
+    Type: String
+  PosixUserUid:
+    Type: String
+  PosixUserGid:
+    Type: String
+  RootDirectoryPath:
+    Type: String
+  VpcConfigSgId:
+    Type: String
+  VpcConfigSubnetId:
+    Type: String
+
+Resources:
+  ManagedAccessPoint:
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      AccessPointTags:
+        - Key: "Name"
+          Value: "simple-file-manager-access-point"
+      FileSystemId: !Ref FileSystemId
+      PosixUser:
+        Gid: !Ref PosixUserGid
+        Uid: !Ref PosixUserUid
+      RootDirectory:
+        CreationInfo:
+          OwnerGid: !Ref PosixUserGid
+          OwnerUid: !Ref PosixUserUid
+          Permissions: 777
+        Path: !Ref RootDirectoryPath
+  ManagedAccessPointFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Description: !Sub "IAM Role for filesystem ${FileSystemId} manager lambda"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+        - "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess"
+      MaxSessionDuration: 3600
+      Path: "/"
+      RoleName: !Sub "${FileSystemId}-manager-role"
+  ManagedAccessPointFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          import os
+          from os import walk
+          import base64
+          import math
+          # File manager operation events:
+          # list: {"operation": "list", "path": "$dir"}
+          # upload: {"operation": "upload", "path": "$dir", "form_data": "$form_data"}
+
+
+          def modify(event):
+              return None
+
+
+          def delete(event):
+              print(event)
+              path = event['path']
+              name = event['name']
+
+              file = path + '/' + name
+
+              try:
+                  os.remove(file)
+              except OSError:
+                  return {"message": "couldn't delete the file", "statusCode": 500}
+              else:
+                  return {"message": "file deletion successful", "statusCode": 200}
+
+
+          def make_dir(event):
+              print(event)
+              path = event['path']
+              name = event['name']
+
+              new_dir = path + '/' + name
+
+              try:
+                  os.mkdir(new_dir)
+              except OSError:
+                  return {"message": "couldn't create the directory", "statusCode": 500}
+              else:
+                  return {"message": "directory creation successful", "statusCode": 200}
+
+
+          def upload(event):
+              print(event)
+              "{'operation': 'upload', 'path': '/mnt/efs', 'chunk_data': {'dzuuid': '10f726ea-ae1d-4363-9a97-4bf6772cd4df', 'dzchunkindex': '0', 'dzchunksize': '1000000', 'dztotalchunkcount': '1', 'dzchunkbyteoffset': '0', 'filename': 'Log at 2020-08-11 12-17-21 PM.txt', 'content': '(Emitted value instead of an instance of Error)'}}"
+              path = event['path']
+              filename = event['chunk_data']['filename']
+              file_content_decoded = base64.b64decode(event['chunk_data']['content'])
+              current_chunk = int(event['chunk_data']['dzchunkindex'])
+              save_path = os.path.join(path, filename)
+
+              if os.path.exists(save_path) and current_chunk == 0:
+                  return {"message": "File already exists", "statusCode": 400}
+
+              try:
+                  with open(save_path, 'ab') as f:
+                      f.seek(int(event['chunk_data']['dzchunkbyteoffset']))
+                      f.write(file_content_decoded)
+              except OSError as error:
+                  print('Could not write to file: {error}'.format(error=error))
+                  return {"message": "couldn't write the file to disk", "statusCode": 500}
+
+              total_chunks = int(event['chunk_data']['dztotalchunkcount'])
+
+              if current_chunk + 1 == total_chunks:
+                  if int(os.path.getsize(save_path)) != int(event['chunk_data']['dztotalfilesize']):
+                      print("File {filename} was completed, but there is a size mismatch. Was {size} but expected {total}".format(filename=filename, size=os.path.getsize(save_path), total=event['chunk_data']['dztotalfilesize']))
+                      return {"message": "Size mismatch", "statusCode": 500}
+                  else:
+                      print("file {filename} has been uploaded successfully".format(filename=filename))
+                      return {"message": "File uploaded successfuly", "statusCode": 200}
+              else:
+                  print("Chunk {current_chunk} of {total_chunks} for file {filename} complete".format(current_chunk=current_chunk + 1 , total_chunks=total_chunks, filename=filename))
+                  return {"message": "Chunk upload successful", "statusCode": 200}
+
+
+          def download(event):
+              # first call {"path": "./", "filename": "test.txt"}
+              # successive calls
+              # {"path": "./", "filename": "test_video.mp4", "chunk_data": {'dzchunkindex': chunk['dzchunkindex'],
+              # 'dzchunkbyteoffset': chunk['dzchunkbyteoffset']}}
+              path = event['path']
+              filename = event['filename']
+              file_path = os.path.join(path, filename)
+              chunk_size = 2000000  # bytes
+              file_size = os.path.getsize(file_path)
+              chunks = math.ceil(file_size / chunk_size)
+
+              if "chunk_data" in event:
+                  start_index = event['chunk_data']['dzchunkbyteoffset']
+                  current_chunk = event['chunk_data']['dzchunkindex']
+                  try:
+                      with open(file_path, 'rb') as f:
+                          f.seek(start_index)
+                          file_content = f.read(chunk_size)
+                          encoded_chunk_content = str(base64.b64encode(file_content), 'utf-8')
+                          chunk_offset = start_index + chunk_size
+                          chunk_number = current_chunk + 1
+
+                          return {"dzchunkindex": chunk_number, "dztotalchunkcount": chunks, "dzchunkbyteoffset": chunk_offset,
+                                  "chunk_data": encoded_chunk_content, "dztotalfilesize": file_size}
+                  except OSError as error:
+                      print('Could not read file: {error}'.format(error=error))
+                      return {"message": "couldn't read the file from disk", "statusCode": 500}
+
+              else:
+                  start_index = 0
+                  try:
+                      with open(file_path, 'rb') as f:
+                          f.seek(start_index)
+                          file_content = f.read(chunk_size)
+                          encoded_chunk_content = str(base64.b64encode(file_content), 'utf-8')
+                          chunk_number = 0
+                          chunk_offset = chunk_size
+
+                          return {"dzchunkindex": chunk_number, "dztotalchunkcount": chunks, "dzchunkbyteoffset": chunk_offset,
+                                  "chunk_data": encoded_chunk_content, "dztotalfilesize": file_size}
+
+                  except OSError as error:
+                      print('Could not read file: {error}'.format(error=error))
+                      return {"message": "couldn't read the file from disk", "statusCode": 500}
+
+
+          def list(event):
+              # get path to list
+              try:
+                  path = event['path']
+              except KeyError:
+                  raise Exception('Missing required parameter in event: "path"')
+
+              try:
+                  # TODO: Mucchhhh better thinking around listing directories
+                  dir_items = []
+                  file_items = []
+                  for (dirpath, dirnames, filenames) in walk(path):
+                      dir_items.extend(dirnames)
+                      file_items.extend(filenames)
+                      break
+              # TODO: narrower exception scope and proper debug output
+              except Exception as error:
+                  print(error)
+                  raise Exception(error)
+              else:
+                  return {"path": path, "directiories": dir_items, "files": file_items, "statusCode": 200}
+
+
+          def lambda_handler(event, context):
+              # get operation type
+              try:
+                  operation_type = event['operation']
+              except KeyError:
+                  raise Exception('Missing required parameter in event: "operation"')
+              else:
+                  if operation_type == 'upload':
+                      upload_result = upload(event)
+                      return upload_result
+                  if operation_type == 'list':
+                      list_result = list(event)
+                      return list_result
+                  if operation_type == 'modify':
+                      modify(event)
+                  if operation_type == 'delete':
+                      delete_result = delete(event)
+                      return delete_result
+                  if operation_type == 'make_dir':
+                      make_dir_result = make_dir(event)
+                      return make_dir_result
+                  if operation_type == 'download':
+                      download_result = download(event)
+                      return download_result
+      Description: !Sub "Lambda function to process file manager operations for filesystem: ${FileSystemId}"
+      FileSystemConfigs:
+        - Arn: !GetAtt ManagedAccessPoint.Arn
+          LocalMountPath: "/mnt/efs"
+      FunctionName: !Sub "${FileSystemId}-manager-lambda"
+      Handler: "index.lambda_handler"
+      MemorySize: 512
+      PackageType: "Zip"
+      Role: !GetAtt ManagedAccessPointFunctionRole.Arn
+      Runtime: "python3.8"
+      Timeout: 60
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref VpcConfigSgId
+        SubnetIds:
+          - !Ref VpcConfigSubnetId

--- a/source/api/chalicelib/file-manager-ap-lambda.template
+++ b/source/api/chalicelib/file-manager-ap-lambda.template
@@ -12,7 +12,7 @@ Parameters:
     Type: String
   VpcConfigSgIds:
     Type: String
-  VpcConfigSubnetId:
+  VpcConfigSubnetIds:
     Type: String
 
 Resources:
@@ -244,4 +244,6 @@ Resources:
             - ","
             - !Ref VpcConfigSgIds
         SubnetIds:
-          - !Ref VpcConfigSubnetId
+          Fn::Split:
+            - ","
+            - !Ref VpcConfigSubnetIds

--- a/source/api/external_resources.json
+++ b/source/api/external_resources.json
@@ -15,6 +15,10 @@
     "ApiHandlerIamRole": {
       "Type": "String",
       "Description": "Arn of the API Handler IAM Role"
+    },
+    "stackPrefix": {
+      "Type": "String",
+      "Description": "Prefix of the main Stack to use for manager resource Stacks"
     }
   },
   "Resources": {
@@ -24,12 +28,11 @@
         "Role": {"Ref": "ApiHandlerIamRole"},
         "Environment": {
           "Variables": {
-                "botoConfig": {
-                  "Ref": "botoConfig"
-                }
-            }
+            "botoConfig": {"Ref": "botoConfig"},
+            "stackPrefix": {"Ref": "stackPrefix"}
+          }
         },
-        "CodeUri": {"Bucket":  {"Ref": "DeploymentPackageBucket"}, "Key":  {"Ref": "DeploymentPackageKey"}}
+        "CodeUri": {"Bucket": {"Ref": "DeploymentPackageBucket"}, "Key": {"Ref": "DeploymentPackageKey"}}
       }
     }
   }

--- a/source/web/src/components/filesystems.vue
+++ b/source/web/src/components/filesystems.vue
@@ -11,13 +11,16 @@
         </template>
         <template v-slot:cell(managed)="data">
             <div v-if="data.value === true">
-                <a :href="`/details/${data.item.file_system_id}`">{{ data.value }}</a>
+                <a :href="`/details/${data.item.file_system_id}`" v-b-tooltip.hover title="Click to unregister file system.">{{ data.value }}</a>
+            </div>
+            <div v-else-if="data.value === 'Deleting'">
+                <b-link href="/" v-b-tooltip.hover title="Stack deletion can take several minutes. Click to refresh.">{{data.value}}</b-link>
             </div>
             <div v-else-if="data.value === 'Creating'">
-                <b-link href="/" v-b-tooltip.hover title="Lambda creation can take several minutes. Click to refresh.">{{data.value}}</b-link>
+                <b-link href="/" v-b-tooltip.hover title="Stack creation can take several minutes. Click to refresh.">{{data.value}}</b-link>
             </div>
             <div v-else>
-                <a :href="`/configure/${data.item.file_system_id}`">{{ data.value }}</a>
+                <a :href="`/configure/${data.item.file_system_id}`" v-b-tooltip.hover title="Click to onboard file system.">{{ data.value }}</a>
             </div>
         </template>
     </b-table>


### PR DESCRIPTION
*Issue #, if available:*
#126 

*Description of changes:*
To address the bug described in the linked issue I switched from imperative API calls to create/delete AWS resources to a more declarative approach based on CloudFormation. This converts the resources creation to all-or-nothing and gives us roll-back capabilities out of the box. Since we can pool for the status of the Stack in one place we can also solve other items like retries/delays that were still pending in the code.

List of changes:
* Changes to main Cfn template to add Cfn-related permissions to API Lambda
* Changes to Chalice conf + Cfn template to pass down to API Lambda the name of the Stack to use as prefix for child Stacks
* Added Cfn template to create managed IAM Role, EFS Access Point, Lambda Function in VPC
* Changes to API Lambda to read template instead of lambda code + create zip
* Changes to API Lambda to create/delete/get status of CloudFormation Stack instead of making direct API Calls
* Changes to track EFS management status based on Cfn Stack status (or lack thereof) instead of Manager Lambda 
* Added new `Deleting` state + tooltips to Web interface 

**If the change is too drastic/too broad and/or not welcome please feel free to close the PR and I'll open a new one with only the minimal changes to fix #126.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
