### PR TITLE
Disabled user existence errors in User Pool

### DIFF
--- a/deployment/efs-file-manager-auth.yaml
+++ b/deployment/efs-file-manager-auth.yaml
@@ -36,6 +36,7 @@ Resources:
     Type: AWS::Cognito::UserPoolClient
     Properties:
       UserPoolId: !Ref SimpleFileManagerUserPool
+      PreventUserExistenceErrors: "ENABLED"
 
     # Service - cognito / security infrastructure
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Enabled `PreventUserExistenceErrors` in the `AWS::Cognito::UserPoolClient` resource inside `deployment/efs-file-manager-ayth.yaml`.

Link to service documentation: [here](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-managing-errors.html).

A reset password attempt made with a non-existent user now returns this response (200 OK) instead of a 4xx one:
```
:status: 200
Date: Thu, 10 Jun 2021 23:06:04 GMT
Access-Control-Expose-Headers: x-amzn-RequestId,x-amzn-ErrorType,x-amzn-ErrorMessage,Date
Content-Type: application/x-amz-json-1.1
Content-Length: 104
Access-Control-Allow-Origin: *
x-amzn-requestid: 95ef94cf-3414-440f-b5c9-3c54ce34bd56
```
Web UI behaves as if it was a legit reset password attempt and goes to the input code screen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
